### PR TITLE
feat: Add SimpleTitle and LogoReveal intro templates

### DIFF
--- a/src/app/intro/IntroClient.tsx
+++ b/src/app/intro/IntroClient.tsx
@@ -37,8 +37,12 @@ export default function IntroClient() {
             return props.duration * 30 + 60;
         } else if (active.id === "BounceText") {
             return props.duration * 30 + 60;
+        } else if (active.id === "SimpleTitle") {
+            return 150; // Fixed duration from Remotion/Root.tsx
+        } else if (active.id === "LogoReveal") {
+            return 180; // Fixed duration from Remotion/Root.tsx
         }
-        return 150;
+        return 150; // Default duration if not specified
     };
 
     const duration = getDuration();
@@ -109,8 +113,8 @@ export default function IntroClient() {
                     component={PreviewComp}
                     inputProps={previewProps}
                     durationInFrames={duration}
-                    compositionWidth={1280}
-                    compositionHeight={720}
+                    compositionWidth={active.width}
+                    compositionHeight={active.height}
                     fps={30}
                     controls
                     style={{

--- a/src/lib/data.tsx
+++ b/src/lib/data.tsx
@@ -6,6 +6,11 @@ import { neonTextSchema, NeonTextTemplate } from "@/remotion/NeonText/NeonTextTe
 import { oldSchoolTextSchema, OldSchoolTextTemplate } from "@/remotion/OldSchoolText/OldSchoolTextTemplate";
 import { slideInTextSchema, SlideInTextTemplate } from "@/remotion/SlideInText/SlideInTextTemplate";
 import { typewriterSchema, TypewriterTemplate } from "@/remotion/Typewriter/TypewriterTemplate";
+import { SimpleTitle, simpleTitleSchema } from "@/remotion/SimpleTitle/SimpleTitleTemplate";
+import { LogoReveal, logoRevealSchema } from "@/remotion/LogoReveal/LogoRevealTemplate";
+import { staticFile } from "remotion";
+
+import { VIDEO_HEIGHT, VIDEO_WIDTH } from "@/types/constants";
 
 type TemplateEntry = {
     id: string;
@@ -13,6 +18,8 @@ type TemplateEntry = {
     schema: any;
     defaultProps: any;
     description?: string;
+    width: number;
+    height: number;
 };
 
 export const templates: TemplateEntry[] = [
@@ -21,6 +28,8 @@ export const templates: TemplateEntry[] = [
         id: "Typewriter",
         comp: TypewriterTemplate,
         schema: typewriterSchema,
+        width: VIDEO_WIDTH, // 1280
+        height: VIDEO_HEIGHT, // 720
         defaultProps: {
             text: "Hello!",
             speed: 5,
@@ -33,6 +42,8 @@ export const templates: TemplateEntry[] = [
         id: "FadeInText",
         comp: FadeInTextTemplate,
         schema: fadeInTextSchema,
+        width: VIDEO_WIDTH,
+        height: VIDEO_HEIGHT,
         defaultProps: {
             text: "Welcome!",
             duration: 3,
@@ -47,6 +58,8 @@ export const templates: TemplateEntry[] = [
         id: "SlideInText",
         comp: SlideInTextTemplate,
         schema: slideInTextSchema,
+        width: VIDEO_WIDTH,
+        height: VIDEO_HEIGHT,
         defaultProps: {
             text: "Slide In!",
             duration: 2,
@@ -61,6 +74,8 @@ export const templates: TemplateEntry[] = [
         id: "BounceText",
         comp: BounceTextTemplate,
         schema: bounceTextSchema,
+        width: VIDEO_WIDTH,
+        height: VIDEO_HEIGHT,
         defaultProps: {
             text: "Bounce!",
             duration: 2,
@@ -75,6 +90,8 @@ export const templates: TemplateEntry[] = [
         id: "FluidText",
         comp: FluidTextTemplate,
         schema: fluidTextSchema,
+        width: VIDEO_WIDTH,
+        height: VIDEO_HEIGHT,
         defaultProps: {
             text: "Fluid Animation",
             duration: 4,
@@ -89,6 +106,8 @@ export const templates: TemplateEntry[] = [
         id: "OldSchoolText",
         comp: OldSchoolTextTemplate,
         schema: oldSchoolTextSchema,
+        width: VIDEO_WIDTH,
+        height: VIDEO_HEIGHT,
         defaultProps: {
             text: "Old School Cool",
             duration: 3,
@@ -102,6 +121,8 @@ export const templates: TemplateEntry[] = [
         id: "NeonText",
         comp: NeonTextTemplate,
         schema: neonTextSchema,
+        width: VIDEO_WIDTH,
+        height: VIDEO_HEIGHT,
         defaultProps: {
             text: "Neon Glow",
             duration: 4,
@@ -115,6 +136,8 @@ export const templates: TemplateEntry[] = [
         id: "FunText",
         comp: FunTextTemplate,
         schema: funTextSchema,
+        width: VIDEO_WIDTH,
+        height: VIDEO_HEIGHT,
         defaultProps: {
             text: "So Much Fun!",
             duration: 3,
@@ -124,6 +147,36 @@ export const templates: TemplateEntry[] = [
             jumpHeight: 30,
             rotationRange: 20,
         },
+    },
+    {
+        id: "SimpleTitle",
+        comp: SimpleTitle,
+        schema: simpleTitleSchema,
+        width: 1920,
+        height: 1080,
+        defaultProps: {
+            titleText: 'My Awesome Title',
+            subtitleText: 'A catchy subtitle here',
+            titleColor: { r: 255, g: 255, b: 255, a: 1 },
+            subtitleColor: { r: 200, g: 200, b: 200, a: 1 },
+            backgroundColor: { r: 20, g: 30, b: 100, a: 1 },
+        },
+        description: "A clean title and subtitle animation.",
+    },
+    {
+        id: "LogoReveal",
+        comp: LogoReveal,
+        schema: logoRevealSchema,
+        width: 1920,
+        height: 1080,
+        defaultProps: {
+            logoUrl: staticFile('logo.webp'), // Make sure public/logo.webp exists
+            taglineText: 'Your Company Tagline',
+            taglineColor: { r: 220, g: 220, b: 220, a: 1 },
+            backgroundColor: { r: 15, g: 15, b: 25, a: 1 },
+            logoScale: 1,
+        },
+        description: "Reveals a logo with an animated tagline.",
     },
 ];
 

--- a/src/remotion/LogoReveal/LogoRevealTemplate.tsx
+++ b/src/remotion/LogoReveal/LogoRevealTemplate.tsx
@@ -1,0 +1,96 @@
+import {AbsoluteFill, Img, staticFile, useCurrentFrame, useVideoConfig, spring, interpolate} from 'remotion';
+import {z} from 'zod';
+import {zColor} from '@remotion/zod-types';
+
+export const logoRevealSchema = z.object({
+  logoUrl: z.string().default(staticFile('logo.webp')), // Assuming a default logo in public folder
+  taglineText: z.string().default('Powered by Remotion'),
+  taglineColor: zColor().default(() => ({r: 220, g: 220, b: 220, a: 1})),
+  backgroundColor: zColor().default(() => ({r: 10, g: 10, b: 25, a: 1})),
+  logoScale: z.number().min(0.1).max(2).default(1),
+});
+
+type LogoRevealProps = z.infer<typeof logoRevealSchema>;
+
+export const LogoReveal: React.FC<LogoRevealProps> = ({
+  logoUrl,
+  taglineText,
+  taglineColor,
+  backgroundColor,
+  logoScale,
+}) => {
+  const frame = useCurrentFrame();
+  const {fps, width, height, durationInFrames} = useVideoConfig();
+
+  const taglineRgb = `rgba(${taglineColor.r}, ${taglineColor.g}, ${taglineColor.b}, ${taglineColor.a})`;
+  const backgroundRgb = `rgba(${backgroundColor.r}, ${backgroundColor.g}, ${backgroundColor.b}, ${backgroundColor.a})`;
+
+  // Logo animation: Scale and fade in
+  const logoEntryProgress = spring({
+    frame,
+    fps,
+    from: 0,
+    to: 1,
+    durationInFrames: fps * 1, // 1 second entry
+  });
+
+  const logoOpacity = interpolate(logoEntryProgress, [0, 0.5, 1], [0, 0.5, 1]);
+  const currentLogoScale = interpolate(logoEntryProgress, [0, 1], [0.5 * logoScale, 1 * logoScale]);
+
+  // Tagline animation: Appears after logo, fades in from bottom
+  const taglineDelay = fps * 0.8; // Start tagline animation slightly before logo finishes
+  const taglineProgress = spring({
+    frame: frame - taglineDelay,
+    fps,
+    from: 0,
+    to: 1,
+    durationInFrames: fps * 0.7,
+  });
+
+  const taglineOpacity = interpolate(taglineProgress, [0, 0.5, 1], [0, 0.8, 1]);
+  const taglineTranslateY = interpolate(taglineProgress, [0, 1], [30, 0]);
+
+  // Hold logo and tagline for a bit, then fade out everything
+  const exitStartTime = durationInFrames - fps * 1; // Start exit 1 second before end
+  const exitProgress = spring({
+    frame: frame - exitStartTime,
+    fps,
+    from: 0,
+    to: 1,
+    durationInFrames: fps * 1,
+  });
+
+  const overallOpacity = interpolate(exitProgress, [0, 0.5, 1], [1, 1, 0], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+  });
+
+
+  return (
+    <AbsoluteFill style={{backgroundColor: backgroundRgb, justifyContent: 'center', alignItems: 'center', fontFamily: 'Helvetica, Arial, sans-serif', opacity: overallOpacity}}>
+      <div style={{textAlign: 'center'}}>
+        <Img
+          src={logoUrl}
+          style={{
+            width: `${200 * currentLogoScale}px`, // Base size 200px, scaled by prop
+            height: 'auto',
+            opacity: logoOpacity,
+            transform: `scale(${currentLogoScale})`,
+            marginBottom: '30px',
+          }}
+        />
+        <p
+          style={{
+            fontSize: `${36 * logoScale}px`, // Scale font size with logo
+            color: taglineRgb,
+            opacity: taglineOpacity,
+            transform: `translateY(${taglineTranslateY}px)`,
+            margin: 0,
+          }}
+        >
+          {taglineText}
+        </p>
+      </div>
+    </AbsoluteFill>
+  );
+};

--- a/src/remotion/Root.tsx
+++ b/src/remotion/Root.tsx
@@ -35,10 +35,44 @@ import {
 } from "./OldSchoolText/OldSchoolTextTemplate";
 import { neonTextSchema, NeonTextTemplate } from "./NeonText/NeonTextTemplate";
 import { funTextSchema, FunTextTemplate } from "./FunText/FunTextTemplate";
+import {SimpleTitle, simpleTitleSchema} from './SimpleTitle/SimpleTitleTemplate';
+import {LogoReveal, logoRevealSchema} from './LogoReveal/LogoRevealTemplate';
 
 export const RemotionRoot: React.FC = () => {
   return (
     <>
+      <Composition
+				id="SimpleTitle"
+				component={SimpleTitle}
+				durationInFrames={150}
+				fps={30}
+				width={1920}
+				height={1080}
+				schema={simpleTitleSchema}
+				defaultProps={{
+					titleText: 'Welcome to Our Channel!',
+					subtitleText: 'Subscribe for more updates.',
+					titleColor: {r: 255, g: 255, b: 255, a: 1},
+					subtitleColor: {r: 200, g: 200, b: 200, a: 1},
+					backgroundColor: {r: 34, g: 102, b: 221, a: 1},
+				}}
+			/>
+			<Composition
+				id="LogoReveal"
+				component={LogoReveal}
+				durationInFrames={180}
+				fps={30}
+				width={1920}
+				height={1080}
+				schema={logoRevealSchema}
+				defaultProps={{
+					taglineText: 'Innovative Solutions',
+					taglineColor: {r: 230, g: 230, b: 230, a: 1},
+					backgroundColor: {r: 20, g: 20, b: 30, a: 1},
+					logoScale: 1,
+					// logoUrl: staticFile('public/default-logo.png'), // Add a default logo to public
+				}}
+			/>
       <Composition
         id="Typewriter"
         component={TypewriterTemplate}

--- a/src/remotion/SimpleTitle/SimpleTitleTemplate.tsx
+++ b/src/remotion/SimpleTitle/SimpleTitleTemplate.tsx
@@ -1,0 +1,91 @@
+import {AbsoluteFill, useCurrentFrame, useVideoConfig, spring, staticFile} from 'remotion';
+import {z} from 'zod';
+import {zColor} from '@remotion/zod-types';
+
+export const simpleTitleSchema = z.object({
+  titleText: z.string().default('Hello World'),
+  subtitleText: z.string().default('Welcome to Remotion'),
+  titleColor: zColor().default(() => ({r: 255, g: 255, b: 255, a: 1})),
+  subtitleColor: zColor().default(() => ({r: 200, g: 200, b: 200, a: 1})),
+  backgroundColor: zColor().default(() => ({r: 0, g: 0, b: 0, a: 1})),
+});
+
+type SimpleTitleProps = z.infer<typeof simpleTitleSchema>;
+
+export const SimpleTitle: React.FC<SimpleTitleProps> = ({
+  titleText,
+  subtitleText,
+  titleColor,
+  subtitleColor,
+  backgroundColor,
+}) => {
+  const frame = useCurrentFrame();
+  const {fps, width, height} = useVideoConfig();
+
+  const titleRgb = `rgba(${titleColor.r}, ${titleColor.g}, ${titleColor.b}, ${titleColor.a})`;
+  const subtitleRgb = `rgba(${subtitleColor.r}, ${subtitleColor.g}, ${subtitleColor.b}, ${subtitleColor.a})`;
+  const backgroundRgb = `rgba(${backgroundColor.r}, ${backgroundColor.g}, ${backgroundColor.b}, ${backgroundColor.a})`;
+
+  // Title animation: Appears after 0.5 seconds
+  const titleOpacity = spring({
+    frame: frame - fps * 0.5,
+    fps,
+    from: 0,
+    to: 1,
+    durationInFrames: fps * 0.5,
+  });
+  const titleTranslateY = spring({
+    frame: frame - fps * 0.5,
+    fps,
+    from: 20,
+    to: 0,
+    durationInFrames: fps * 0.5,
+  });
+
+  // Subtitle animation: Appears after 1 second
+  const subtitleOpacity = spring({
+    frame: frame - fps * 1,
+    fps,
+    from: 0,
+    to: 1,
+    durationInFrames: fps * 0.5,
+  });
+  const subtitleTranslateY = spring({
+    frame: frame - fps * 1,
+    fps,
+    from: 20,
+    to: 0,
+    durationInFrames: fps * 0.5,
+  });
+
+  return (
+    <AbsoluteFill style={{backgroundColor: backgroundRgb, justifyContent: 'center', alignItems: 'center', fontFamily: 'Arial, sans-serif'}}>
+      <div style={{textAlign: 'center'}}>
+        <h1
+          style={{
+            fontSize: '72px',
+            color: titleRgb,
+            opacity: titleOpacity,
+            transform: `translateY(${titleTranslateY}px)`,
+            margin: 0,
+            marginBottom: '20px',
+          }}
+        >
+          {titleText}
+        </h1>
+        <h2
+          style={{
+            fontSize: '42px',
+            color: subtitleRgb,
+            opacity: subtitleOpacity,
+            transform: `translateY(${subtitleTranslateY}px)`,
+            margin: 0,
+            fontWeight: 'normal'
+          }}
+        >
+          {subtitleText}
+        </h2>
+      </div>
+    </AbsoluteFill>
+  );
+};


### PR DESCRIPTION
- Created SimpleTitle and LogoReveal Remotion templates with customizable text, colors, and (for LogoReveal) logo URL and scale.
- Integrated these templates into the existing application, making them selectable in the UI.
- Enhanced TemplateEditor to support zColor objects, URL inputs, and specific numeric sliders.
- Updated IntroClient to handle dynamic preview resolutions based on selected template dimensions.
- Ensured backend rendering API supports the new templates.
- Updated TEMPLATE_CREATION_GUIDE.md with latest information.